### PR TITLE
Explicit "unhandled" error responsibilies

### DIFF
--- a/dist/tests/SyncTasksTests.js
+++ b/dist/tests/SyncTasksTests.js
@@ -539,6 +539,48 @@ describe('SyncTasks', function () {
             done();
         }, 20);
     });
+    it('"unhandledErrorHandler": "done" does not create another "unhandled"', function (done) {
+        var unhandledErrorHandlerCalled = false;
+        var catchBlockReached = false;
+        var oldUnhandledErrorHandler = SyncTasks.config.unhandledErrorHandler;
+        SyncTasks.config.unhandledErrorHandler = function () {
+            unhandledErrorHandlerCalled = true;
+        };
+        SyncTasks.Rejected().done(function () {
+            // Should not create a separate "unhandled" error since there is no way to "handle" it from here.
+            // The existing "unhandled" error should continue to be "unhandled", as other tests have verified.
+        }).catch(function () {
+            // "Handle" the failure.
+            catchBlockReached = true;
+        });
+        setTimeout(function () {
+            SyncTasks.config.unhandledErrorHandler = oldUnhandledErrorHandler;
+            assert(!unhandledErrorHandlerCalled);
+            assert(catchBlockReached);
+            done();
+        }, 20);
+    });
+    it('"unhandledErrorHandler": "fail" does not create another "unhandled"', function (done) {
+        var unhandledErrorHandlerCalled = false;
+        var catchBlockReached = false;
+        var oldUnhandledErrorHandler = SyncTasks.config.unhandledErrorHandler;
+        SyncTasks.config.unhandledErrorHandler = function () {
+            unhandledErrorHandlerCalled = true;
+        };
+        SyncTasks.Rejected().fail(function () {
+            // Should not create a separate "unhandled" error since there is no way to "handle" it from here.
+            // The existing "unhandled" error should continue to be "unhandled", as other tests have verified.
+        }).catch(function () {
+            // "Handle" the failure.
+            catchBlockReached = true;
+        });
+        setTimeout(function () {
+            SyncTasks.config.unhandledErrorHandler = oldUnhandledErrorHandler;
+            assert(!unhandledErrorHandlerCalled);
+            assert(catchBlockReached);
+            done();
+        }, 20);
+    });
     it('Add callback while resolving', function (done) {
         var task = SyncTasks.Defer();
         var promise = task.promise();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctasks",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -655,6 +655,56 @@ describe('SyncTasks', function () {
         }, 20);
     });
 
+    it('"unhandledErrorHandler": "done" does not create another "unhandled"', (done) => {
+        let unhandledErrorHandlerCalled = false;
+        let catchBlockReached = false;
+        
+        const oldUnhandledErrorHandler = SyncTasks.config.unhandledErrorHandler;
+        SyncTasks.config.unhandledErrorHandler = () => {
+            unhandledErrorHandlerCalled = true;
+        }
+        
+        SyncTasks.Rejected<number>().done(() => {
+            // Should not create a separate "unhandled" error since there is no way to "handle" it from here.
+            // The existing "unhandled" error should continue to be "unhandled", as other tests have verified.
+        }).catch(() => {
+            // "Handle" the failure.
+            catchBlockReached = true;
+        })
+        
+        setTimeout(() => {
+            SyncTasks.config.unhandledErrorHandler = oldUnhandledErrorHandler;
+            assert(!unhandledErrorHandlerCalled);
+            assert(catchBlockReached);
+            done();
+        }, 20);
+    });
+
+    it('"unhandledErrorHandler": "fail" does not create another "unhandled"', (done) => {
+        let unhandledErrorHandlerCalled = false;
+        let catchBlockReached = false;
+        
+        const oldUnhandledErrorHandler = SyncTasks.config.unhandledErrorHandler;
+        SyncTasks.config.unhandledErrorHandler = () => {
+            unhandledErrorHandlerCalled = true;
+        }
+        
+        SyncTasks.Rejected<number>().fail(() => {
+            // Should not create a separate "unhandled" error since there is no way to "handle" it from here.
+            // The existing "unhandled" error should continue to be "unhandled", as other tests have verified.
+        }).catch(() => {
+            // "Handle" the failure.
+            catchBlockReached = true;
+        })
+        
+        setTimeout(() => {
+            SyncTasks.config.unhandledErrorHandler = oldUnhandledErrorHandler;
+            assert(!unhandledErrorHandlerCalled);
+            assert(catchBlockReached);
+            done();
+        }, 20);
+    });
+
     it('Add callback while resolving', (done) => {
         const task = SyncTasks.Defer<number>();
         const promise = task.promise();


### PR DESCRIPTION
Made the responsibility more explicit for who needs to "handle" any errors, and ensured .done/.fail/.finally never took that responsibility. This fixes a bug where Rejected().done().catch() would report the .done promise was "unhandled" even though clearly everything was "handled".