### PR TITLE
throw String changed to throw Error as in case of throwing string the…

### DIFF
--- a/dist/SyncTasks.js
+++ b/dist/SyncTasks.js
@@ -190,7 +190,7 @@ var Internal;
         };
         SyncTask.prototype.resolve = function (obj) {
             if (this._completedSuccess || this._completedFail) {
-                throw 'Already Completed';
+                throw new Error('Already Completed');
             }
             this._completedSuccess = true;
             this._storedResolution = obj;
@@ -199,7 +199,7 @@ var Internal;
         };
         SyncTask.prototype.reject = function (obj) {
             if (this._completedSuccess || this._completedFail) {
-                throw 'Already Completed';
+                throw new Error('Already Completed');
             }
             this._completedFail = true;
             this._storedErrResolution = obj;
@@ -231,7 +231,7 @@ var Internal;
         SyncTask.prototype.cancel = function (context) {
             var _this = this;
             if (this._wasCanceled) {
-                throw 'Already Canceled';
+                throw new Error('Already Canceled');
             }
             this._wasCanceled = true;
             this._cancelContext = context;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctasks",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -268,7 +268,7 @@ module Internal {
 
         resolve(obj?: T): Deferred<T> {
             if (this._completedSuccess || this._completedFail) {
-                throw 'Already Completed';
+                throw new Error('Already Completed');
             }
             this._completedSuccess = true;
             this._storedResolution = obj;
@@ -280,7 +280,7 @@ module Internal {
 
         reject(obj?: any): Deferred<T> {
             if (this._completedSuccess || this._completedFail) {
-                throw 'Already Completed';
+                throw new Error('Already Completed');
             }
             this._completedFail = true;
             this._storedErrResolution = obj;
@@ -320,7 +320,7 @@ module Internal {
 
         cancel(context?: any): void {
             if (this._wasCanceled) {
-                throw 'Already Canceled';
+                throw new Error('Already Canceled');
             }
 
             this._wasCanceled = true;


### PR DESCRIPTION
…re is no stacktrace so thirdparty frameworks can't correctly chain the exceptions/display full stacktrace