### PR TITLE
sergeyd/synctask asserts detailed logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ SyncTasks has the basic `Defer` call, but also helper methods to save on common 
 - `fromThenable(thenable)` - A handy helper function to wrap any sort of `Thenable` (usually used for wrapping ES6 Promises) into
     a SyncTask.  This takes the thenable and maps its success and failure cases into a new `SyncTasks.Promise` that resolve and
     reject with the results of the passed thenable.
+- `setTracingEnabled(boolean)` - This option allows enabling of double resolution tracing individually per Promise.
+    Could be used in the release in cases then the problem couldn't be reproduced locally.
+    If option enabled assert will give you two stack traces - for the first resolve and the second. By default, you would see only second resolve stack trace.
+    Keep in mind that it adds an extra overhead as resolve method call will create an extra Error object, so it should be used with caution in the release. 
+    Estimated overhead on mobile is around 0.05ms per resolve/reject call on Nexus 5x android.
 
 ### SyncTasks.Deferred Reference
 

--- a/dist/SyncTasks.d.ts
+++ b/dist/SyncTasks.d.ts
@@ -13,6 +13,7 @@
 export declare const config: {
     exceptionsToConsole: boolean;
     catchExceptions: boolean;
+    traceEnabled: boolean;
     exceptionHandler: (ex: Error) => void;
     unhandledErrorHandler: (err: any) => void;
 };

--- a/dist/SyncTasks.d.ts
+++ b/dist/SyncTasks.d.ts
@@ -50,6 +50,7 @@ export interface Promise<T> extends Thenable<T>, Cancelable {
     done(successFunc: (value: T) => void): Promise<T>;
     fail(errorFunc: (error: any) => void): Promise<T>;
     thenAsync<U>(successFunc: SuccessFunc<T, U>, errorFunc?: ErrorFunc<U>): Promise<U>;
+    setTracingEnabled(enabled: boolean): void;
 }
 export declare type Raceable<T> = T | Thenable<T>;
 export declare function all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>, Raceable<T6>, Raceable<T7>, Raceable<T8>, Raceable<T9>, Raceable<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;

--- a/dist/SyncTasks.d.ts
+++ b/dist/SyncTasks.d.ts
@@ -50,7 +50,7 @@ export interface Promise<T> extends Thenable<T>, Cancelable {
     done(successFunc: (value: T) => void): Promise<T>;
     fail(errorFunc: (error: any) => void): Promise<T>;
     thenAsync<U>(successFunc: SuccessFunc<T, U>, errorFunc?: ErrorFunc<U>): Promise<U>;
-    setTracingEnabled(enabled: boolean): void;
+    setTracingEnabled(enabled: boolean): Promise<T>;
 }
 export declare type Raceable<T> = T | Thenable<T>;
 export declare function all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>, Raceable<T6>, Raceable<T7>, Raceable<T8>, Raceable<T9>, Raceable<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;

--- a/dist/SyncTasks.js
+++ b/dist/SyncTasks.js
@@ -190,23 +190,26 @@ var Internal;
             return this;
         };
         SyncTask.prototype.resolve = function (obj) {
-            if (this._completedSuccess || this._completedFail) {
-                throw new Error('Already Completed');
-            }
+            this._checkState(true);
             this._completedSuccess = true;
             this._storedResolution = obj;
             this._resolveSuccesses();
             return this;
         };
         SyncTask.prototype.reject = function (obj) {
-            if (this._completedSuccess || this._completedFail) {
-                throw new Error('Already Completed');
-            }
+            this._checkState(false);
             this._completedFail = true;
             this._storedErrResolution = obj;
             this._resolveFailures();
             SyncTask._enforceErrorHandled(this);
             return this;
+        };
+        SyncTask.prototype._checkState = function (resolve) {
+            if (this._completedSuccess || this._completedFail) {
+                var message = 'Failed to ' + resolve ? 'resolve' : 'reject' +
+                    ' the task already ' + this._completedSuccess ? 'resolved' : 'rejected';
+                throw new Error(message);
+            }
         };
         // Make sure any rejected task has its failured handled.
         SyncTask._enforceErrorHandled = function (task) {

--- a/dist/SyncTasks.js
+++ b/dist/SyncTasks.js
@@ -21,7 +21,7 @@ exports.config = {
     // digging through a stack trace.
     catchExceptions: true,
     // Use this option in order to debug double resolution asserts locally.
-    // Enabling this option globally in release could have a negative impact on application performance.
+    // Enabling this option in the release would have a negative impact on the application performance.
     traceEnabled: false,
     exceptionHandler: null,
     // If an ErrorFunc is not added to the task (then, catch, always) before the task rejects or synchonously

--- a/dist/SyncTasks.js
+++ b/dist/SyncTasks.js
@@ -20,6 +20,9 @@ exports.config = {
     // Disable this for debugging when you'd rather the debugger caught the exception synchronously rather than
     // digging through a stack trace.
     catchExceptions: true,
+    // Use this option in order to debug double resolution asserts locally.
+    // Enabling this option globally in release could have a negative impact on application performance.
+    traceEnabled: false,
     exceptionHandler: null,
     // If an ErrorFunc is not added to the task (then, catch, always) before the task rejects or synchonously
     // after that, then this function is called with the error. Default throws the error.
@@ -215,10 +218,10 @@ var Internal;
                     console.error(this._completeStack.message, this._completeStack.stack);
                 }
                 var message = 'Failed to ' + resolve ? 'resolve' : 'reject' +
-                    ' the task is already ' + this._completedSuccess ? 'resolved' : 'rejected';
+                    ': the task is already ' + this._completedSuccess ? 'resolved' : 'rejected';
                 throw new Error(message);
             }
-            if (this._traceEnabled) {
+            if (exports.config.traceEnabled || this._traceEnabled) {
                 this._completeStack = new Error('Initial ' + resolve ? 'resolve' : 'reject');
             }
         };

--- a/dist/SyncTasks.js
+++ b/dist/SyncTasks.js
@@ -103,6 +103,7 @@ var Internal;
         function SyncTask() {
             this._completedSuccess = false;
             this._completedFail = false;
+            this._traceEnabled = false;
             this._cancelCallbacks = [];
             this._wasCanceled = false;
             this._resolving = false;
@@ -168,6 +169,9 @@ var Internal;
                 failFunc: func
             }, true);
         };
+        SyncTask.prototype.setTracingEnabled = function (enabled) {
+            this._traceEnabled = enabled;
+        };
         // Finally should let you inspect the value of the promise as it passes through without affecting the then chaining
         // i.e. a failed promise with a finally after it should then chain to the fail case of the next then
         SyncTask.prototype.finally = function (func) {
@@ -206,9 +210,15 @@ var Internal;
         };
         SyncTask.prototype._checkState = function (resolve) {
             if (this._completedSuccess || this._completedFail) {
+                if (this._completeStack) {
+                    console.error(this._completeStack.message, this._completeStack.stack);
+                }
                 var message = 'Failed to ' + resolve ? 'resolve' : 'reject' +
-                    ' the task already ' + this._completedSuccess ? 'resolved' : 'rejected';
+                    ' the task is already ' + this._completedSuccess ? 'resolved' : 'rejected';
                 throw new Error(message);
+            }
+            if (this._traceEnabled) {
+                this._completeStack = new Error('Initial ' + resolve ? 'resolve' : 'reject');
             }
         };
         // Make sure any rejected task has its failured handled.

--- a/dist/SyncTasks.js
+++ b/dist/SyncTasks.js
@@ -171,6 +171,7 @@ var Internal;
         };
         SyncTask.prototype.setTracingEnabled = function (enabled) {
             this._traceEnabled = enabled;
+            return this;
         };
         // Finally should let you inspect the value of the promise as it passes through without affecting the then chaining
         // i.e. a failed promise with a finally after it should then chain to the fail case of the next then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctasks",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "mocha dist/tests/synctaskstests.js",
     "webtest": "webpack",
-    "build": "npm run tslint|| true && tsc",
-    "tslint": "tslint --project tsconfig.json -r tslint.json --fix"
+    "build": "npm run tslint && tsc",
+    "tslint": "tslint --project tsconfig.json -r tslint.json --fix || true"
   },
   "main": "dist/SyncTasks.js",
   "devDependencies": {

--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -153,7 +153,7 @@ export interface Promise<T> extends Thenable<T>, Cancelable {
     // the second. By default you would see only second resolve.
     // Option adds extra overhead as on resolve Error object would be created, so it should be used
     // with caution on release. Estimated overhead on mobile is around 0.5ms per error created on Nexus 5x android.
-    setTracingEnabled(enabled: boolean): void;
+    setTracingEnabled(enabled: boolean): Promise<T>;
 }
 
 module Internal {
@@ -253,8 +253,9 @@ module Internal {
             }, true);
         }
 
-        setTracingEnabled(enabled: boolean) : void {
+        setTracingEnabled(enabled: boolean) : Promise<T> {
             this._traceEnabled = enabled;
+            return this;
         }
     
         // Finally should let you inspect the value of the promise as it passes through without affecting the then chaining

--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -22,7 +22,7 @@ export const config = {
     catchExceptions: true,
 
     // Use this option in order to debug double resolution asserts locally.
-    // Enabling this option globally in release could have a negative impact on application performance.
+    // Enabling this option in the release would have a negative impact on the application performance.
     traceEnabled: false,
 
     exceptionHandler: <(ex: Error) => void>null,
@@ -152,13 +152,6 @@ export interface Promise<T> extends Thenable<T>, Cancelable {
     // Defer the resolution of the then until the next event loop, simulating standard A+ promise behavior
     thenAsync<U>(successFunc: SuccessFunc<T, U>, errorFunc?: ErrorFunc<U>): Promise<U>;
 
-    // This option allows enabling of double resolution tracing individually per Promise.
-    // Could be used in the release build in cases problem couldn't be reproduced locally.
-    // In case of double resolve assert you will get two stack traces - for the first resolve and
-    // the second. By default, you would see only second resolve.
-    // Option adds extra overhead as resolve method call will create extra Error object, so it should be used
-    // with caution in the release. 
-    // Estimated overhead on mobile is around 0.05ms per Error created on Nexus 5x android.
     setTracingEnabled(enabled: boolean): Promise<T>;
 }
 


### PR DESCRIPTION
Currently, it's hard to debug SyncTasks assert for double resolutions in complex cases.
In order to improve it I'm adding following changes:

1. Assert has a text with a type of the first resolve and type of the second resolve, so the reader of the stack traces would have more information about the problem he investigating.
2. It's possible to turn on stack traces for the first resolution by setting setEnableTraces(true) on the Promise returned by the API.


