### PR TITLE
0.2.18 - Fixed promise cancellation bubbling

### DIFF
--- a/dist/SyncTasks.js
+++ b/dist/SyncTasks.js
@@ -257,8 +257,7 @@ var Internal;
         SyncTask.prototype.cancel = function (context) {
             var _this = this;
             if (this._wasCanceled) {
-                console.warn('SyncTasks: Already Canceled');
-                return;
+                throw new Error('Already Canceled');
             }
             this._wasCanceled = true;
             this._cancelContext = context;
@@ -304,6 +303,7 @@ var Internal;
                         else {
                             callback.task.onCancel(function (context) { return ret.cancel(context); });
                         }
+                        // Note: don't care if ret is canceled. We don't need to bubble out since this is already resolved.
                     }
                     if (isThenable(ret)) {
                         // The success block of a then returned a new promise, so
@@ -340,6 +340,7 @@ var Internal;
                                 else {
                                     callback.task.onCancel(function (context) { return ret.cancel(context); });
                                 }
+                                // Note: don't care if ret is canceled. We don't need to bubble out since this is already rejected.
                             }
                             if (isThenable(ret)) {
                                 ret.then(function (r) { callback.task.resolve(r); }, function (e) { callback.task.reject(e); });

--- a/dist/tests/SyncTasksTests.js
+++ b/dist/tests/SyncTasksTests.js
@@ -694,7 +694,6 @@ describe('SyncTasks', function () {
         var cancelContext;
         var task = SyncTasks.Defer();
         var promise = task.promise();
-        promise.cancel(4);
         var ret = promise.then(function () {
             var newTask = SyncTasks.Defer();
             newTask.onCancel(function (context) {
@@ -712,6 +711,7 @@ describe('SyncTasks', function () {
             assert.equal(cancelContext, 4);
             return SyncTasks.Resolved();
         });
+        ret.cancel(4);
         task.resolve();
         return ret;
     });
@@ -728,7 +728,7 @@ describe('SyncTasks', function () {
                 newTask.reject(5);
             });
             setTimeout(function () {
-                promise.cancel(4);
+                ret.cancel(4);
             }, 100);
             return newTask.promise();
         }, function (err) {
@@ -748,7 +748,6 @@ describe('SyncTasks', function () {
         var cancelContext;
         var task = SyncTasks.Defer();
         var promise = task.promise();
-        promise.cancel(4);
         var ret = promise.then(function () {
             var newTask = SyncTasks.Defer();
             newTask.onCancel(function (context) {
@@ -769,6 +768,7 @@ describe('SyncTasks', function () {
             assert.equal(cancelContext, 4);
             return SyncTasks.Resolved();
         });
+        ret.cancel(4);
         task.resolve();
         return ret;
     });
@@ -785,7 +785,7 @@ describe('SyncTasks', function () {
                 newTask.reject(5);
             });
             setTimeout(function () {
-                promise.cancel(4);
+                ret.cancel(4);
             }, 100);
             return newTask.promise().then(function () {
                 // Chain another promise in place to make sure it works its way up to the newTask at some point.
@@ -808,7 +808,6 @@ describe('SyncTasks', function () {
         var cancelContext;
         var task = SyncTasks.Defer();
         var promise = task.promise();
-        promise.cancel(4);
         var ret = promise.then(function () {
             var newTask = SyncTasks.Defer();
             newTask.onCancel(function (context) {
@@ -829,6 +828,7 @@ describe('SyncTasks', function () {
             assert.equal(cancelContext, 4);
             return SyncTasks.Resolved();
         });
+        ret.cancel(4);
         task.resolve();
         return ret;
     });
@@ -845,7 +845,7 @@ describe('SyncTasks', function () {
                 newTask.reject(5);
             });
             setTimeout(function () {
-                promise.cancel(4);
+                ret.cancel(4);
             }, 100);
             return SyncTasks.all([newTask.promise()]).then(function () {
                 // Chain another promise in place to make sure it works its way up to the newTask at some point.
@@ -862,6 +862,27 @@ describe('SyncTasks', function () {
         });
         task.resolve();
         return ret;
+    });
+    it('Cancel two children tasks does not throw', function () {
+        var task = SyncTasks.Defer();
+        var p = task.promise();
+        var p1 = p.then(function () { return 1; });
+        var p2 = p.then(function () { return 2; });
+        p1.cancel('Cancels p');
+        p2.cancel('Also cancels p');
+    });
+    it('Cancel two children tasks does not call provided onCancel callback twice', function () {
+        var wasCanceled = false;
+        var task = SyncTasks.Defer();
+        task.onCancel(function (key) {
+            assert(!wasCanceled);
+            wasCanceled = true;
+        });
+        var p = task.promise();
+        var p1 = p.then(function () { return 1; });
+        var p2 = p.then(function () { return 2; });
+        p1.cancel('Cancels p');
+        p2.cancel('Also cancels p');
     });
     it('deferCallback', function (done) {
         var got = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctasks",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -7,6 +7,8 @@ import SyncTasks = require('../SyncTasks');
 describe('SyncTasks', function () {
     function noop() {/*noop*/}
 
+    // Amount of time to wait to ensure all sync and trivially async (e.g. setTimeout(..., 0)) things have finished.
+    // Useful to do something 'later'.
     const waitTime = 25;
 
     it('Simple - null resolve after then', (done) => {
@@ -857,7 +859,10 @@ describe('SyncTasks', function () {
             assert(canceled);
             assert.equal(cancelContext, 4);
             return -1;
-        }).always(noop)
+        })
+            // Make the chain longer to further separate the cancel from the task.
+            .always(noop)
+            .always(noop)
             .always(noop);
 
         chain.cancel(4);


### PR DESCRIPTION
If this is canceled then do not cancel children. If a callback returns a promise and the callback is canceled then cancel the returned promise.