### PR TITLE
Fixing a bug I noticed in resolution.  resolved promise.catch().then(…

### DIFF
--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -429,8 +429,6 @@ module Internal {
                     this._handleException(e, 'SyncTask caught exception in success block: ' + e.toString());
                     callback.task!!!.reject(e);
                 });
-            } else {
-                callback.task!!!.resolve(this._storedResolution);
             }
         }
 

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -777,6 +777,40 @@ describe('SyncTasks', function () {
         });
     });
 
+    it('Resolved promise with a catch block should not resolve the catch to the next then', done => {
+        let a = SyncTasks.Defer<number>();
+        let ap = a.promise();
+        let bad = false;
+        ap.catch(err => 'c').then(num => {
+            // Should never get here
+            bad = true;
+            assert(false);
+        });
+        a.resolve(4);
+        setTimeout(() => {
+            if (!bad) {
+                done();
+            }
+        }, waitTime);
+    });
+
+    it('Resolved promise with a catch block should not resolve the catch to the next then, early resolve', done => {
+        let a = SyncTasks.Defer<number>();
+        a.resolve(4);
+        let ap = a.promise();
+        let bad = false;
+        ap.catch(err => 'c').then(num => {
+            // Should never get here
+            bad = true;
+            assert(false);
+        });
+        setTimeout(() => {
+            if (!bad) {
+                done();
+            }
+        }, waitTime);
+    });
+        
     it('Cancel task (happy path)', () => {
         let canceled = false;
         let cancelContext: any;


### PR DESCRIPTION
…) shouldn't resolve the .then() since the .catch was never triggered