### PR TITLE
Limiting what catch() can return to enforce proper types

### DIFF
--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -127,7 +127,7 @@ export interface Cancelable {
 }
 
 export interface Promise<T> extends Thenable<T>, Cancelable {
-    catch<U>(errorFunc: ErrorFunc<U>): Promise<U>;
+    catch(errorFunc: ErrorFunc<T>): Promise<T>;
 
     finally(func: (value: T|any) => void): Promise<T>;
 
@@ -239,8 +239,8 @@ module Internal {
             }, true);
         }
 
-        catch<U>(errorFunc: ErrorFunc<U>): Promise<U> {
-            return this._addCallbackSet<U>({
+        catch(errorFunc: ErrorFunc<T>): Promise<T> {
+            return this._addCallbackSet<T>({
                 failFunc: errorFunc
             }, true);
         }


### PR DESCRIPTION
Previously catch could return U, which would make the actual Promise it was returning a Promise<T|U>, which caused havoc to be honest about.  The better solution seems to be enforce that catch() returns the same type it was passed since it can pass through values.