### PR TITLE
From what appears to be a remnant of a former era (probably from befo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctasks",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -103,8 +103,8 @@ function resolveAsyncCallbacks() {
     }
 }
 
-export type SuccessFunc<T, U> = (value: T) => U | Thenable<U> | void;
-export type ErrorFunc<U> = (error: any) => U | Thenable<U> | void;
+export type SuccessFunc<T, U> = (value: T) => U | Thenable<U>;
+export type ErrorFunc<U> = (error: any) => U | Thenable<U>;
 export type CancelFunc = (context: any) => void;
 
 export interface Deferred<T> {

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -176,7 +176,7 @@ describe('SyncTasks', function () {
             });
         }, err => {
             assert(false);
-            return undefined;
+            return 2;
         }).then(val => {
             assert.equal(val, 5, 'outer');
             done();
@@ -621,7 +621,7 @@ describe('SyncTasks', function () {
             unhandledErrorHandlerCalled = true;
         };
         
-        const task = SyncTasks.Rejected<number>();
+        const task = SyncTasks.Rejected<void>();
         task.catch(() => {
             catchBlockReached = true;
         });
@@ -670,7 +670,7 @@ describe('SyncTasks', function () {
             unhandledErrorHandlerCalled = true;
         };
         
-        SyncTasks.Rejected<number>().done(() => {
+        SyncTasks.Rejected<void>().done(() => {
             // Should not create a separate "unhandled" error since there is no way to "handle" it from here.
             // The existing "unhandled" error should continue to be "unhandled", as other tests have verified.
         }).catch(() => {
@@ -695,7 +695,7 @@ describe('SyncTasks', function () {
             unhandledErrorHandlerCalled = true;
         };
         
-        SyncTasks.Rejected<number>().fail(() => {
+        SyncTasks.Rejected<void>().fail(() => {
             // Should not create a separate "unhandled" error since there is no way to "handle" it from here.
             // The existing "unhandled" error should continue to be "unhandled", as other tests have verified.
         }).catch(() => {


### PR DESCRIPTION
…re TS could properly interpret U = void), we had |void on SuccessFunc and ErrorFunc, which was letting people get away with murder on function returns from task resolution in .then, .catch, etc.