### PR TITLE
Fix a memory leak in SyncTasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctasks",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -286,6 +286,8 @@ module Internal {
            this._checkState(true);
            this._completedSuccess = true;
            this._storedResolution = obj;
+           // Cannot cancel resolved promise - nuke chain
+           this._cancelCallbacks = [];
 
            this._resolveSuccesses();
 
@@ -296,6 +298,8 @@ module Internal {
            this._checkState(false);
            this._completedFail = true;
            this._storedErrResolution = obj;
+           // Cannot cancel resolved promise - nuke chain
+           this._cancelCallbacks = [];
 
            this._resolveFailures();
 
@@ -362,9 +366,11 @@ module Internal {
 
             this._wasCanceled = true;
             this._cancelContext = context;
+            const callbacks = this._cancelCallbacks;
+            this._cancelCallbacks = [];
 
-            if (this._cancelCallbacks.length > 0) {
-                this._cancelCallbacks.forEach(callback => {
+            if (callbacks.length > 0) {
+                callbacks.forEach(callback => {
                     if (!this._completedSuccess && !this._completedFail) {
                         callback(this._cancelContext);
                     }

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -1454,7 +1454,7 @@ describe('SyncTasks', function () {
         }
     });
 
-    it('Cancel resovled promise does not call cancelation handlers', () => {
+    it('Cancel resovled promise does not call cancellation handlers', () => {
         const defer = SyncTasks.Defer<void>();
         const promise = defer.promise();
 
@@ -1466,7 +1466,7 @@ describe('SyncTasks', function () {
         promise.cancel();
     });
 
-    it('Multiple bubble promise cancelation results in single cancel handler callbacks', () => {
+    it('Multiple bubble promise cancellation results in single cancel handler callbacks', () => {
         const defer = SyncTasks.Defer<void>();
         const promise1 = defer.promise().then(() => { /* noop */});
         const promise2 = defer.promise().then(() => { /* noop */});

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -1454,6 +1454,34 @@ describe('SyncTasks', function () {
         }
     });
 
+    it('Cancel resovled promise does not call cancelation handlers', () => {
+        const defer = SyncTasks.Defer<void>();
+        const promise = defer.promise();
+
+        defer.onCancel(() => {
+            assert(false, 'Handler should not be called');
+        });
+
+        defer.resolve(void 0);
+        promise.cancel();
+    });
+
+    it('Multiple bubble promise cancelation results in single cancel handler callbacks', () => {
+        const defer = SyncTasks.Defer<void>();
+        const promise1 = defer.promise().then(() => { /* noop */});
+        const promise2 = defer.promise().then(() => { /* noop */});
+        let callbackCount = 0;
+
+        defer.onCancel(() => {
+            callbackCount++;
+        });
+
+        promise1.cancel();
+        promise2.cancel();
+
+        assert.equal(callbackCount, 1, 'onCancel handler not called correct number of times');
+    });
+
     it('deferCallback', (done) => {
         let got = false;
         let got2 = false;

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -1454,7 +1454,7 @@ describe('SyncTasks', function () {
         }
     });
 
-    it('Cancel resovled promise does not call cancellation handlers', () => {
+    it('Cancel resolved promise does not call cancellation handlers', () => {
         const defer = SyncTasks.Defer<void>();
         const promise = defer.promise();
 


### PR DESCRIPTION
Resolved and Rejected promises that had cancelation blocks were not being GC'd since the cancelCallback array was held even after resolution.
An additional side-effect allowed the onCancel block to be called for promises that were canceled after completion BUT we didn't allow adding new onCancel blocks. Make this behaviour consistant