### PR TITLE
Remove deprecated dependency. TS Update. Fix tslint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {
-    "prepublish": "tsc",
-    "test": "mocha dist/tests/synctaskstests.js",
+    "prepare": "tsc",
+    "test": "mocha dist/tests/SyncTasksTests.js",
     "webtest": "webpack",
     "build": "npm run tslint && tsc",
     "tslint": "tslint --project tsconfig.json -r tslint.json --fix || true"
@@ -15,13 +15,10 @@
     "@types/mocha": "2.2.40",
     "awesome-typescript-loader": "3.2.1",
     "mocha": "^3.1.2",
-    "tslint": "5.4.3",
-    "tslint-microsoft-contrib": "5.0.0",
-    "typescript": "2.6.0-dev.20170826",
+    "tslint": "5.10.0",
+    "tslint-microsoft-contrib": "5.0.3",
+    "typescript": "2.8.3",
     "webpack": "3.3.0"
-  },
-  "dependencies": {
-    "@types/es6-promise": "^0.0.33"
   },
   "repository": {
     "type": "git",

--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -525,14 +525,17 @@ export function all<T1, T2, T3, T4, T5, T6, T7, T8>(
     values: [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>, Raceable<T6>, Raceable<T7>, Raceable<T8>]
 ): STPromise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
 
-export function all<T1, T2, T3, T4, T5, T6, T7>(values:
- [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>, Raceable<T6>, Raceable<T7>]): STPromise<[T1, T2, T3, T4, T5, T6, T7]>;
+export function all<T1, T2, T3, T4, T5, T6, T7>(
+    values: [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>, Raceable<T6>, Raceable<T7>]
+): STPromise<[T1, T2, T3, T4, T5, T6, T7]>;
 
-export function all<T1, T2, T3, T4, T5, T6>(values:
- [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>, Raceable<T6>]): STPromise<[T1, T2, T3, T4, T5, T6]>;
+export function all<T1, T2, T3, T4, T5, T6>(
+    values: [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>, Raceable<T6>]
+): STPromise<[T1, T2, T3, T4, T5, T6]>;
 
-export function all<T1, T2, T3, T4, T5>(values:
-[Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>]): STPromise<[T1, T2, T3, T4, T5]>;
+export function all<T1, T2, T3, T4, T5>(
+    values: [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>, Raceable<T5>]
+): STPromise<[T1, T2, T3, T4, T5]>;
 
 export function all<T1, T2, T3, T4>(values: [Raceable<T1>, Raceable<T2>, Raceable<T3>, Raceable<T4>]): STPromise<[T1, T2, T3, T4]>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,20 @@
 {
     "compilerOptions": {
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitReturns": true,
+        "strictNullChecks": true,
+        "noUnusedLocals": true,
+        "noImplicitThis": true,
+        "noImplicitAny": true,
         "declaration": true,
         "noResolve": false,
         "module": "commonjs",
         "target": "es5",
-        "outDir": "dist/",
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": true,
-        "strictNullChecks": true,
-        "forceConsistentCasingInFileNames": true
+        "outDir": "dist",
+        "lib": ["es5", "dom", "es2015.promise"]
     },
-    
-    "filesGlob": [
-        "src/**/*{ts,tsx}",
-        "src/typings/**/*.d.ts"
-    ],
-    
-    "exclude": [
-        "dist",
-        "node_modules"
+
+    "include": [
+        "src/**/*"
     ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,7 @@
     "forin": true,
     "indent": [true, "spaces"],
     "label-position": true,
-    "max-line-length": [ true, 140 ],
+    "max-line-length": [true, 140],
     "no-arg": true,
     "no-bitwise": false,
     "no-consecutive-blank-lines":  true,


### PR DESCRIPTION
This PR includes the following changes:

1. Remove deprecated dependency([@types/es6-promise](https://www.npmjs.com/package/@types/es6-promise) - was added in PR [SyncTasks/17](https://github.com/Microsoft/SyncTasks/pull/17)).
2. Fix tslint warnings
3. Fix `npm run test` command _(does not work in master branch)_
4. Update TS to the latest stable version _(2.8.3)_