### PR TITLE
Better type safety for raceTimer result…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctasks",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "An explicitly non-A+ Promise library that resolves promises synchronously",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SyncTasks.ts
+++ b/src/SyncTasks.ts
@@ -684,15 +684,15 @@ export function race(items: any[]): STPromise<any> {
     return outTask.promise();
 }
 
-export type RaceTimerResponse<T> = { timedOut: boolean, result?: T };
+export type RaceTimerResponse<T> = { timedOut: true, result: undefined }|{ timedOut: false, result: T };
 export function raceTimer<T>(promise: STPromise<T>, timeMs: number): STPromise<RaceTimerResponse<T>> {
     let timerDef = Defer<RaceTimerResponse<T>>();
     const token = setTimeout(() => {
-        timerDef.resolve({ timedOut: true });
+        timerDef.resolve({ timedOut: true, result: undefined });
     }, timeMs);
-    const adaptedPromise = promise.then(resp => {
+    const adaptedPromise = promise.then<RaceTimerResponse<T>>(resp => {
         clearTimeout(token);
-        return { timedOut: false, result: resp } as RaceTimerResponse<T>;
+        return { timedOut: false, result: resp };
     });
     return race([adaptedPromise, timerDef.promise()]);
 }

--- a/src/tests/SyncTasksTests.ts
+++ b/src/tests/SyncTasksTests.ts
@@ -461,6 +461,43 @@ describe('SyncTasks', function () {
         task.resolve(2);
     });
 
+    it('"raceTimer" basic success', (done) => {
+        const task = SyncTasks.Defer<number>();
+
+        SyncTasks.raceTimer(task.promise(), 20).then(ret => {
+            assert.equal(ret.timedOut, false);
+            assert.equal(ret.result, 1);
+            done();
+        }, err => {
+            assert(false);
+        });
+
+        task.resolve(1);
+    });
+
+    it('"raceTimer" basic failure', (done) => {
+        const task = SyncTasks.Defer<number>();
+
+        SyncTasks.raceTimer(task.promise(), 20).then(ret => {
+            assert(false);
+        }, err => {
+            assert.equal(err, 1);
+            done();
+        });
+
+        task.reject(1);
+    });
+
+    it('"raceTimer" basic timeout', (done) => {
+        SyncTasks.raceTimer(SyncTasks.Defer<number>().promise(), 10).then(ret => {
+            assert.equal(ret.timedOut, true);
+            assert.equal(ret.result, undefined);
+            done();
+        }, err => {
+            assert(false);
+        });
+    });
+
     it('Callbacks resolve synchronously', (done) => {
         const task = SyncTasks.Defer<number>();
         let resolvedCount = 0;


### PR DESCRIPTION
`.timedOut` determines the type of `.result`. Also, added basic tests for raceTimer.